### PR TITLE
TAG_START inline parser

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -28,6 +28,7 @@ const (
 	ImageNode             NodeType = "IMAGE"
 	LinkNode              NodeType = "LINK"
 	AutoLinkNode          NodeType = "AUTO_LINK"
+	TagStartNode          NodeType = "TAG_START"
 	TagNode               NodeType = "TAG"
 	StrikethroughNode     NodeType = "STRIKETHROUGH"
 	EscapingCharacterNode NodeType = "ESCAPING_CHARACTER"

--- a/ast/inline.go
+++ b/ast/inline.go
@@ -139,6 +139,20 @@ func (n *AutoLink) Restore() string {
 	return fmt.Sprintf("<%s>", n.URL)
 }
 
+type TagStart struct {
+	BaseInline
+
+	Content string
+}
+
+func (*TagStart) Type() NodeType {
+	return TagStartNode
+}
+
+func (n *TagStart) Restore() string {
+	return fmt.Sprintf("#%s", n.Content)
+}
+
 type Tag struct {
 	BaseInline
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -78,6 +78,7 @@ var defaultInlineParsers = []InlineParser{
 	NewSuperscriptParser(),
 	NewMathParser(),
 	NewReferencedContentParser(),
+	NewTagStartParser(),
 	NewTagParser(),
 	NewStrikethroughParser(),
 	NewLineBreakParser(),

--- a/parser/tag_start.go
+++ b/parser/tag_start.go
@@ -1,0 +1,51 @@
+package parser
+
+import (
+	"github.com/usememos/gomark/ast"
+	"github.com/usememos/gomark/parser/tokenizer"
+)
+
+const TagMinLen = 6    // #[[x]]
+const TagPrefixLen = 3 // #[[
+
+type TagPartialParser struct{}
+
+func NewTagPartialParser() InlineParser {
+	return &TagPartialParser{}
+}
+
+func (*TagPartialParser) Match(tokens []*tokenizer.Token) (ast.Node, int) {
+	matchedTokens := tokenizer.GetFirstLine(tokens)
+	if len(matchedTokens) < TagMinLen {
+		return nil, 0
+	}
+	if matchedTokens[0].Type != tokenizer.PoundSign && matchedTokens[1].Type != tokenizer.LeftSquareBracket && matchedTokens[2].Type != tokenizer.LeftSquareBracket {
+		return nil, 0
+	}
+
+	contentTokens := []*tokenizer.Token{}
+	tagEndMatched := false
+
+	for cursor := TagPrefixLen; cursor < len(matchedTokens)-1; cursor++ {
+		token, nextToken := matchedTokens[cursor], matchedTokens[cursor+1]
+
+		if token.Type == tokenizer.Space || token.Type == tokenizer.PoundSign {
+			break
+		}
+
+		if token.Type == tokenizer.RightSquareBracket && nextToken.Type == tokenizer.RightSquareBracket {
+			tagEndMatched = true
+			break
+		}
+
+		contentTokens = append(contentTokens, token)
+	}
+
+	if !tagEndMatched || len(contentTokens) == 0 {
+		return nil, 0
+	}
+
+	return &ast.TagStart{
+		Content: tokenizer.Stringify(contentTokens),
+	}, len(contentTokens) + 1
+}

--- a/parser/tag_start.go
+++ b/parser/tag_start.go
@@ -19,7 +19,7 @@ func (*TagStartParser) Match(tokens []*tokenizer.Token) (ast.Node, int) {
 	if len(matchedTokens) < TagMinLen {
 		return nil, 0
 	}
-	if matchedTokens[0].Type != tokenizer.PoundSign && matchedTokens[1].Type != tokenizer.LeftSquareBracket && matchedTokens[2].Type != tokenizer.LeftSquareBracket {
+	if matchedTokens[0].Type != tokenizer.PoundSign || matchedTokens[1].Type != tokenizer.LeftSquareBracket || matchedTokens[2].Type != tokenizer.LeftSquareBracket {
 		return nil, 0
 	}
 

--- a/parser/tag_start.go
+++ b/parser/tag_start.go
@@ -7,6 +7,7 @@ import (
 
 const TagMinLen = 6    // #[[x]]
 const TagPrefixLen = 3 // #[[
+const TagSuffixLen = 2 // ]]
 
 type TagStartParser struct{}
 
@@ -45,7 +46,9 @@ func (*TagStartParser) Match(tokens []*tokenizer.Token) (ast.Node, int) {
 		return nil, 0
 	}
 
+	usedTokenSize := len(contentTokens) + TagPrefixLen + TagSuffixLen
+
 	return &ast.TagStart{
 		Content: tokenizer.Stringify(contentTokens),
-	}, len(contentTokens) + 1
+	}, usedTokenSize
 }

--- a/parser/tag_start.go
+++ b/parser/tag_start.go
@@ -8,13 +8,13 @@ import (
 const TagMinLen = 6    // #[[x]]
 const TagPrefixLen = 3 // #[[
 
-type TagPartialParser struct{}
+type TagStartParser struct{}
 
-func NewTagPartialParser() InlineParser {
-	return &TagPartialParser{}
+func NewTagStartParser() InlineParser {
+	return &TagStartParser{}
 }
 
-func (*TagPartialParser) Match(tokens []*tokenizer.Token) (ast.Node, int) {
+func (*TagStartParser) Match(tokens []*tokenizer.Token) (ast.Node, int) {
 	matchedTokens := tokenizer.GetFirstLine(tokens)
 	if len(matchedTokens) < TagMinLen {
 		return nil, 0

--- a/parser/tag_start_test.go
+++ b/parser/tag_start_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/usememos/gomark/restore"
 )
 
-func TestTagPartialParser(t *testing.T) {
+func TestTagStartParser(t *testing.T) {
 	tests := []struct {
 		text string
 		tag  ast.Node
@@ -77,7 +77,7 @@ func TestTagPartialParser(t *testing.T) {
 
 	for _, test := range tests {
 		tokens := tokenizer.Tokenize(test.text)
-		node, _ := NewTagPartialParser().Match(tokens)
+		node, _ := NewTagStartParser().Match(tokens)
 		require.Equal(t, restore.Restore([]ast.Node{test.tag}), restore.Restore([]ast.Node{node}))
 	}
 }

--- a/parser/tag_start_test.go
+++ b/parser/tag_start_test.go
@@ -1,0 +1,83 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/gomark/ast"
+	"github.com/usememos/gomark/parser/tokenizer"
+	"github.com/usememos/gomark/restore"
+)
+
+func TestTagPartialParser(t *testing.T) {
+	tests := []struct {
+		text string
+		tag  ast.Node
+	}{
+		{
+			text: "# Hello World",
+			tag:  nil,
+		},
+		{
+			text: "#HelloWorld",
+			tag:  nil,
+		},
+		{
+			text: "#[[]]",
+			tag:  nil,
+		},
+		{
+			text: "#[[ ]]",
+			tag:  nil,
+		},
+		{
+			text: "#[[tag",
+			tag:  nil,
+		},
+		{
+			text: "#[[tag ]]",
+			tag:  nil,
+		},
+		{
+			text: "#[[x]]",
+			tag: &ast.Tag{
+				Content: "x",
+			},
+		},
+		{
+			text: "#[[foo]]",
+			tag: &ast.Tag{
+				Content: "foo",
+			},
+		},
+		{
+			text: "#[[foo]]bar",
+			tag: &ast.Tag{
+				Content: "foo",
+			},
+		},
+		{
+			text: "#[[foo]] bar",
+			tag: &ast.Tag{
+				Content: "foo",
+			},
+		},
+		{
+			text: "#tag/subtag",
+			tag:  nil,
+		},
+		{
+			text: "#[[tag/subtag]]",
+			tag: &ast.Tag{
+				Content: "tag/subtag",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		tokens := tokenizer.Tokenize(test.text)
+		node, _ := NewTagPartialParser().Match(tokens)
+		require.Equal(t, restore.Restore([]ast.Node{test.tag}), restore.Restore([]ast.Node{node}))
+	}
+}

--- a/parser/tag_start_test.go
+++ b/parser/tag_start_test.go
@@ -40,6 +40,10 @@ func TestTagStartParser(t *testing.T) {
 			tag:  nil,
 		},
 		{
+			text: " #[[inline]] tag",
+			tag:  nil,
+		},
+		{
 			text: "#[[x]]",
 			tag: &ast.Tag{
 				Content: "x",


### PR DESCRIPTION
Adding a parser to allow for partial string tagging from the start of a string.

The current #tag parser looks for " " and # to find the end of a tag, limiting how tags can be used in text. 
e.g. 
#Foo's bar should have #Foo as the tag, currently it is #Foo's
#Foo: "Bar" should have #Foo as the tag, currently it is #Foo:

This is creating a list of tag mutations that makes using tags as filters a challenge as you only get partial results back by selecting the main topic or you need to select multiple tags for the same topic

This PR aims to allow for the user to indicate where a tag ends
e.g. 
#[[Foo]]'s bar has #Foo as the tag
#[[Foo]]: "Bar" has #Foo as the tag