### PR TITLE
fix: Use \| in a table to escape |

### DIFF
--- a/parser/table.go
+++ b/parser/table.go
@@ -153,23 +153,25 @@ func matchTableCellTokens(tokens []*tokenizer.Token) (int, bool) {
 	}
 
 	pipes := 0
-	escapePipe := false
-	var preToken *tokenizer.Token = nil
-	for _, token := range tokens {
-		if (token.Type == tokenizer.Pipe) && !escapePipe {
-			pipes++
-		} else if (token.Type == tokenizer.Pipe) && escapePipe {
-			token.Type = ""
-			token.Value = "|"
-			preToken.Type = ""
-			preToken.Value = ""
-		}
+	escapeNextPipe := false
+	for i, token := range tokens {
 		if token.Type == tokenizer.Backslash {
-			escapePipe = true
-		} else {
-			escapePipe = false
+			escapeNextPipe = true
+			continue
 		}
-		preToken = token
+		if token.Type == tokenizer.Pipe {
+			if escapeNextPipe {
+				tokens[i].Type = ""
+				tokens[i].Value = "|"
+				tokens[i-1].Type = ""
+				tokens[i-1].Value = ""
+				escapeNextPipe = false
+			} else {
+				pipes++
+			}
+		} else {
+			escapeNextPipe = false
+		}
 	}
 	cells := tokenizer.Split(tokens, tokenizer.Pipe)
 	if len(cells) != pipes+1 {

--- a/parser/table.go
+++ b/parser/table.go
@@ -153,10 +153,23 @@ func matchTableCellTokens(tokens []*tokenizer.Token) (int, bool) {
 	}
 
 	pipes := 0
+	escapePipe := false
+	var preToken *tokenizer.Token = nil
 	for _, token := range tokens {
-		if token.Type == tokenizer.Pipe {
+		if (token.Type == tokenizer.Pipe) && !escapePipe {
 			pipes++
+		} else if (token.Type == tokenizer.Pipe) && escapePipe {
+			token.Type = ""
+			token.Value = "|"
+			preToken.Type = ""
+			preToken.Value = ""
 		}
+		if token.Type == tokenizer.Backslash {
+			escapePipe = true
+		} else {
+			escapePipe = false
+		}
+		preToken = token
 	}
 	cells := tokenizer.Split(tokens, tokenizer.Pipe)
 	if len(cells) != pipes+1 {

--- a/parser/tests/table_test.go
+++ b/parser/tests/table_test.go
@@ -85,6 +85,28 @@ func TestTableParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			text: "| header |\n| --- |\n| cell\\|\\|cell |\n",
+			node: &ast.Table{
+				Header: []ast.Node{
+					&ast.Paragraph{
+						Children: []ast.Node{
+							&ast.Text{Content: "header"},
+						},
+					},
+				},
+				Delimiter: []string{"---"},
+				Rows: [][]ast.Node{
+					{
+						&ast.Paragraph{
+							Children: []ast.Node{
+								&ast.Text{Content: "cell||cell"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
this pr fix [issue#9](https://github.com/usememos/gomark/issues/9)
Allow user to use \| in a table to escape |