### PR TITLE
Bug: Punctuation after tag included in tag

### DIFF
--- a/parser/tests/tag_test.go
+++ b/parser/tests/tag_test.go
@@ -40,6 +40,18 @@ func TestTagParser(t *testing.T) {
 				Content: "tag",
 			},
 		},
+		// {
+		// 	text: "#endofsentence. more",
+		// 	node: &ast.Tag{
+		// 		Content: "endofsentence",
+		// 	},
+		// },
+		{
+			text: "#pause, for more",
+			node: &ast.Tag{
+				Content: "pause",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
I believe that tags should not have trailing punctuation included within them. Eg. `This #one, here` should result in the tag without punctuation — `one` — not the tag including punctuation — `one,`

I'm not entirely sure what's intended with the parser here (as I can see `#tag/subtag` is intended to be a single unit of tag `tag/subtag`, and the test with `#tag\'s 123` seems to imply that `#tag's` — without the (escaping?) backslash — should also be a single unit of tag `tag's`).

The first commit in this draft PR adds two tests that illustrate the issue I'm seeing. Could one of the maintainers (@boojack?):

- Let me know if these failing tests are accurately illustrating a bug?
- What punctuation should be allowed as part of a tag ? (So I can fix the bug without creating others)

I'm used to tags that would include `#tag`, `#PascalTag`, `#007`; but would only partially match `#tag-two` (→ `#tag`), `#snake_tag` (→ `#snake`), or `#mum's` (→ `#mum`) — ie. the tag finishes at the first punctuation. If you agree with this (with the exception of including the `/` punctuation as a subtag marker) then I'll bake that into the PR I produce as a fix.