### PR TITLE
feat: support escaped square brackets in link text

### DIFF
--- a/parser/link.go
+++ b/parser/link.go
@@ -20,21 +20,32 @@ func (*LinkParser) Match(tokens []*tokenizer.Token) (ast.Node, int) {
 		return nil, 0
 	}
 
+	var slashes int
 	textTokens := []*tokenizer.Token{}
-	for _, token := range matchedTokens[1:] {
-		if token.Type == tokenizer.RightSquareBracket {
-			break
+	for i, token := range matchedTokens[1:] {
+		if token.Type == tokenizer.LeftSquareBracket {
+			if i > 0 && matchedTokens[i].Type == tokenizer.Backslash {
+				textTokens = textTokens[:len(textTokens)-1]
+				slashes++
+			}
+		} else if token.Type == tokenizer.RightSquareBracket {
+			if i > 0 && matchedTokens[i].Type == tokenizer.Backslash {
+				textTokens = textTokens[:len(textTokens)-1]
+				slashes++
+			} else {
+				break
+			}
 		}
 		textTokens = append(textTokens, token)
 	}
-	if len(textTokens)+4 >= len(matchedTokens) {
+	if len(textTokens)+slashes+4 >= len(matchedTokens) {
 		return nil, 0
 	}
-	if matchedTokens[2+len(textTokens)].Type != tokenizer.LeftParenthesis {
+	if matchedTokens[2+len(textTokens)+slashes].Type != tokenizer.LeftParenthesis {
 		return nil, 0
 	}
 	urlTokens, matched := []*tokenizer.Token{}, false
-	for _, token := range matchedTokens[3+len(textTokens):] {
+	for _, token := range matchedTokens[3+len(textTokens)+slashes:] {
 		if token.Type == tokenizer.Space {
 			return nil, 0
 		}
@@ -51,5 +62,5 @@ func (*LinkParser) Match(tokens []*tokenizer.Token) (ast.Node, int) {
 	return &ast.Link{
 		Text: tokenizer.Stringify(textTokens),
 		URL:  tokenizer.Stringify(urlTokens),
-	}, 4 + len(textTokens) + len(urlTokens)
+	}, 4 + len(textTokens) + slashes + len(urlTokens)
 }

--- a/parser/tests/link_test.go
+++ b/parser/tests/link_test.go
@@ -43,6 +43,24 @@ func TestLinkParser(t *testing.T) {
 				URL:  "https://example.com",
 			},
 		},
+		{
+			text: `[\[link text\]](https://example.com)`,
+			node: &ast.Link{
+				Text: `[link text]`,
+				URL:  "https://example.com",
+			},
+		},
+		{
+			text: `[[link text\]](https://example.com)`,
+			node: &ast.Link{
+				Text: `[link text]`,
+				URL:  "https://example.com",
+			},
+		},
+		{
+			text: `[\[link text]](https://example.com)`,
+			node: nil,
+		},
 	}
 	for _, test := range tests {
 		tokens := tokenizer.Tokenize(test.text)


### PR DESCRIPTION
https://github.com/usememos/gomark/issues/17